### PR TITLE
Refactor gazel to write all BUILD files in one pass at the end, and add --validate mode

### DIFF
--- a/README
+++ b/README
@@ -51,3 +51,9 @@ The latest tagged release of gazel is v7. To get the latest
 stable version of gazel run:
 
 $ go get -u gopkg.in/mikedanese/gazel.v7/gazel
+
+Validating BUILD files in CI:
+
+If you run gazel with --validate, it will not update any BUILD files, but it
+will exit nonzero if any BUILD files are out-of-date. You can add --print-diff
+to print out the changes needed.

--- a/gazel/gazel.go
+++ b/gazel/gazel.go
@@ -57,12 +57,9 @@ func main() {
 	if written, err = v.reconcileAllRules(); err != nil {
 		glog.Fatalf("err reconciling rules: %v", err)
 	}
-	if *validate {
-		if written > 0 {
-			fmt.Fprintf(os.Stderr, "\n%d BUILD files not up-to-date.\n", written)
-			os.Exit(1)
-		}
-		fmt.Fprintf(os.Stderr, "All BUILD files up-to-date.\n")
+	if *validate && written > 0 {
+		fmt.Fprintf(os.Stderr, "\n%d BUILD files not up-to-date.\n", written)
+		os.Exit(1)
 	}
 }
 

--- a/gazel/gazel.go
+++ b/gazel/gazel.go
@@ -680,11 +680,11 @@ func writeFile(path string, f *bzl.File, exists, dryRun bool) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		if bytes.Compare(out, orig) == 0 {
+		if bytes.Compare(orig, out) == 0 {
 			return false, nil
 		}
 		if *printDiff {
-			Diff(out, orig)
+			Diff(orig, out)
 		}
 	}
 	if dryRun {


### PR DESCRIPTION
Part of working towards https://github.com/mikedanese/gazel/issues/12.

This PR should functionally be mostly a no-op (though we don't have any tests to confirm...). I've manually tested on kubernetes/test-infra, where it seems to DTRT.

The only functional change here is that `BUILD.bazel` files are supported, if they already exist. When creating new files, we still default to `BUILD`.