### PR TITLE
Add a sourcerer which walks all BUILD files in the repo

### DIFF
--- a/README
+++ b/README
@@ -62,7 +62,7 @@ The "all-srcs" rule includes both the "package-srcs" rule and
 the "all-srcs" rules of all subpackages; i.e. //:all-srcs will
 include all files in your repository.
 
-The "package-srcs" rule defauls to private visibility,
+The "package-srcs" rule defaults to private visibility,
 since it is safer to depend on the "all-srcs" rule: if a
 subpackage is added, the "package-srcs" rule will no longer
 include those files.

--- a/README
+++ b/README
@@ -45,6 +45,33 @@ rule after initial creation so you can add and managed other
 attributes like data and copts and gazel will respect your
 changes.
 
+gazel automatically formats all BUILD files in your repository
+except for those matching SkippedPaths.
+
+Adding "sources" rules:
+
+If you set "AddSourcesRules": true in your .gazelcfg.json,
+gazel will create "package-srcs" and "all-srcs" rules in every
+package.
+
+The "package-srcs" rule is a glob matching all files in the
+package recursively, but not any files owned by packages in
+subdirectories.
+
+The "all-srcs" rule includes both the "package-srcs" rule and
+the "all-srcs" rules of all subpackages; i.e. //:all-srcs will
+include all files in your repository.
+
+The "package-srcs" rule defauls to private visibility,
+since it is safer to depend on the "all-srcs" rule: if a
+subpackage is added, the "package-srcs" rule will no longer
+include those files.
+
+You can remove the "automanaged" tag from the "package-srcs"
+rule if you need to modify the glob (such as adding excludes).
+It's recommended that you leave the "all-srcs" rule
+automanaged.
+
 Getting latest stable version:
 
 The latest tagged release of gazel is v7. To get the latest

--- a/gazel/BUILD
+++ b/gazel/BUILD
@@ -20,6 +20,7 @@ go_library(
         "config.go",
         "diff.go",
         "gazel.go",
+        "sourcerer.go",
     ],
     tags = ["automanaged"],
     deps = [

--- a/gazel/config.go
+++ b/gazel/config.go
@@ -11,6 +11,9 @@ type Cfg struct {
 	SrcDirs []string
 	// regexps that match packages to skip
 	SkippedPaths []string
+	// whether to add "pkg-srcs" and "all-srcs" filegroups
+	// note that this operates on the entire tree (not just SrcsDirs) but skips anything matching SkippedPaths
+	AddSourcesRules bool
 }
 
 func ReadCfg(cfgPath string) (*Cfg, error) {

--- a/gazel/gazel.go
+++ b/gazel/gazel.go
@@ -641,6 +641,7 @@ func ReconcileRules(pkgPath string, rules []*bzl.Rule, dryRun bool) (bool, error
 func reconcileLoad(f *bzl.File, rules []*bzl.Rule) {
 	usedRuleKindsMap := map[string]bool{}
 	for _, r := range rules {
+		// Select only the Go rules we need to import, excluding builtins like filegroup.
 		// TODO: make less fragile
 		if strings.HasPrefix(r.Kind(), "go_") || strings.HasPrefix(r.Kind(), "cgo_") {
 			usedRuleKindsMap[r.Kind()] = true

--- a/gazel/gazel.go
+++ b/gazel/gazel.go
@@ -53,6 +53,9 @@ func main() {
 	if err := v.walkRepo(); err != nil {
 		glog.Fatalf("err walking repo: %v", err)
 	}
+	if _, err := v.walkSource(*root); err != nil {
+		glog.Fatalf("err walking source: %v", err)
+	}
 	written := 0
 	if written, err = v.reconcileAllRules(); err != nil {
 		glog.Fatalf("err reconciling rules: %v", err)
@@ -244,6 +247,7 @@ const (
 	RuleTypeGoTest
 	RuleTypeGoXTest
 	RuleTypeCGoGenrule
+	RuleTypeFileGroup
 )
 
 func (rt RuleType) RuleKind() string {
@@ -258,6 +262,8 @@ func (rt RuleType) RuleKind() string {
 		return "go_test"
 	case RuleTypeCGoGenrule:
 		return "cgo_genrule"
+	case RuleTypeFileGroup:
+		return "filegroup"
 	}
 	panic("unreachable")
 }
@@ -621,21 +627,24 @@ func ReconcileRules(pkgPath string, rules []*bzl.Rule, dryRun bool) (bool, error
 		delete(oldRules, r.Name())
 	}
 
-	reconcileLoad(f, rules)
-
 	for _, r := range oldRules {
 		if !RuleIsManaged(r) {
 			continue
 		}
 		f.DelRules(r.Kind(), r.Name())
 	}
+	reconcileLoad(f, f.Rules(""))
+
 	return writeFile(path, f, true, dryRun)
 }
 
 func reconcileLoad(f *bzl.File, rules []*bzl.Rule) {
 	usedRuleKindsMap := map[string]bool{}
 	for _, r := range rules {
-		usedRuleKindsMap[r.Kind()] = true
+		// TODO: make less fragile
+		if strings.HasPrefix(r.Kind(), "go_") || strings.HasPrefix(r.Kind(), "cgo_") {
+			usedRuleKindsMap[r.Kind()] = true
+		}
 	}
 
 	usedRuleKindsList := []string{}

--- a/gazel/sourcerer.go
+++ b/gazel/sourcerer.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	bzl "github.com/bazelbuild/buildifier/core"
+)
+
+const (
+	pkgSrcsTarget = "package-srcs"
+	allSrcsTarget = "all-srcs"
+)
+
+// walkSource walks the source tree recursively from pkgPath, adding
+// any BUILD files to v.newRules to be formatted.
+//
+// If AddSourcesRules is enabled in the Gazel config, then we additionally add
+// package-sources and recursive all-srcs filegroups rules to every BUILD file.
+//
+// Returns the list of children all-srcs targets that should be added to the
+// all-srcs rule of the enclosing package.
+func (v *Vendorer) walkSource(pkgPath string) ([]string, error) {
+	// clean pkgPath since we access v.newRules directly
+	pkgPath = filepath.Clean(pkgPath)
+	for _, r := range v.skippedPaths {
+		if r.Match([]byte(pkgPath)) {
+			return nil, nil
+		}
+	}
+	files, err := ioutil.ReadDir(pkgPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Find any children packages we need to include in an all-srcs rule.
+	var children []string = nil
+	for _, f := range files {
+		if f.IsDir() {
+			c, err := v.walkSource(filepath.Join(pkgPath, f.Name()))
+			if err != nil {
+				return nil, err
+			}
+			children = append(children, c...)
+		}
+	}
+
+	// This path is a package either if we've added rules or if a BUILD file already exists.
+	_, hasRules := v.newRules[pkgPath]
+	isPkg := hasRules
+	if !isPkg {
+		isPkg, _ = findBuildFile(pkgPath)
+	}
+
+	if !isPkg {
+		// This directory isn't a package (doesn't contain a BUILD file),
+		// but there might be subdirectories that are packages,
+		// so pass that up to our parent.
+		return children, nil
+	}
+
+	// Enforce formatting the BUILD file, even if we're not adding srcs rules
+	if !hasRules {
+		v.addRules(pkgPath, nil)
+	}
+
+	if !v.cfg.AddSourcesRules {
+		return nil, nil
+	}
+
+	pkgSrcsExpr := &bzl.LiteralExpr{Token: `glob(["**"])`}
+	if pkgPath == "." {
+		pkgSrcsExpr = &bzl.LiteralExpr{Token: `glob(["**"], exclude=["bazel-*/**", ".git/**"])`}
+	}
+
+	v.addRules(pkgPath, []*bzl.Rule{
+		newRule(RuleTypeFileGroup,
+			func(_ RuleType) string { return pkgSrcsTarget },
+			map[string]bzl.Expr{
+				"srcs":       pkgSrcsExpr,
+				"visibility": asExpr([]string{"//visibility:private"}),
+			}),
+		newRule(RuleTypeFileGroup,
+			func(_ RuleType) string { return allSrcsTarget },
+			map[string]bzl.Expr{
+				"srcs": asExpr(append(children, fmt.Sprintf(":%s", pkgSrcsTarget))),
+			}),
+	})
+	return []string{fmt.Sprintf("//%s:%s", pkgPath, allSrcsTarget)}, nil
+}


### PR DESCRIPTION
All `BUILD` files are run through the buildifier formatter.

Optionally, if `.gazelcfg.json` sets `"AddSourcesRules": true`, then add `package-srcs` and `all-srcs` rules to every `BUILD` file.

I've hopefully explained why we need `package-srcs` and `all-srcs` in the README and comments; basically, we want to make sure there's one rule that's always automanaged and one that can be locally customized as needed.

Fixes #12.