### PR TITLE
Search for BUILD.bazel before BUILD

### DIFF
--- a/gazel/gazel.go
+++ b/gazel/gazel.go
@@ -574,7 +574,7 @@ func newRule(rt RuleType, namer NamerFunc, attrs map[string]bzl.Expr) *bzl.Rule 
 // findBuildFile determines the name of a preexisting BUILD file, returning
 // a default if no such file exists.
 func findBuildFile(pkgPath string) (bool, string) {
-	options := []string{"BUILD", "BUILD.bazel"}
+	options := []string{"BUILD.bazel", "BUILD"}
 	for _, b := range options {
 		path := filepath.Join(pkgPath, b)
 		info, err := os.Stat(path)
@@ -582,7 +582,7 @@ func findBuildFile(pkgPath string) (bool, string) {
 			return true, path
 		}
 	}
-	return false, filepath.Join(pkgPath, options[0])
+	return false, filepath.Join(pkgPath, "BUILD")
 }
 
 func ReconcileRules(pkgPath string, rules []*bzl.Rule, dryRun bool) (bool, error) {


### PR DESCRIPTION
The current search order fails on case-insensitive filesystems if
a normal file called "build" exist in the path, because it'll only
fall back to BUILD.bazel if "build" is a directory. This will also
cause issues if the build dir isn't created yet. If there's a
BUILD.bazel file it's safe to assume the user has decided to use
that naming for a reason, so we should check for that first and
prefer it.

AKA "Mac OS X is fun for everyone"