### PR TITLE
Use unified diff, and overall context

### DIFF
--- a/gazel/diff.go
+++ b/gazel/diff.go
@@ -7,14 +7,14 @@ import (
 )
 
 func Diff(left, right []byte) error {
-	lf, err := ioutil.TempFile("/tmp", "gazel-diff")
+	lf, err := ioutil.TempFile("/tmp", "actual-file-")
 	if err != nil {
 		return err
 	}
 	defer lf.Close()
 	defer os.Remove(lf.Name())
 
-	rf, err := ioutil.TempFile("/tmp", "gazel-diff")
+	rf, err := ioutil.TempFile("/tmp", "expected-file-")
 	if err != nil {
 		return err
 	}
@@ -33,7 +33,7 @@ func Diff(left, right []byte) error {
 	}
 	rf.Close()
 
-	cmd := exec.Command("/usr/bin/diff", lf.Name(), rf.Name())
+	cmd := exec.Command("/usr/bin/diff", "-u", lf.Name(), rf.Name())
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Run()


### PR DESCRIPTION
Current output is hard to read for a human, you have a piece of diff
somewhere that is hard to isolate and/or understand.

Unified diff provides more context, and also add a comment so that one
can know what's going on.