### PR TITLE
Add an option to generate Kubernetes' OpenAPI rule.

### DIFF
--- a/gazel/BUILD
+++ b/gazel/BUILD
@@ -20,6 +20,7 @@ go_library(
         "config.go",
         "diff.go",
         "gazel.go",
+        "generator.go",
         "sourcerer.go",
     ],
     tags = ["automanaged"],

--- a/gazel/config.go
+++ b/gazel/config.go
@@ -16,6 +16,8 @@ type Cfg struct {
 	AddSourcesRules bool
 	// whether to have multiple build files in vendor/ or just one.
 	VendorMultipleBuildFiles bool
+	// whether to manage kubernetes' pkg/generated/openapi.
+	K8sOpenAPIGen bool
 }
 
 func ReadCfg(cfgPath string) (*Cfg, error) {

--- a/gazel/generator.go
+++ b/gazel/generator.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	openAPIGenTag = "// +k8s:openapi-gen"
+
+	baseImport = "k8s.io/kubernetes/"
+	staging    = "staging/src/"
+)
+
+// walkGenerated updates the rule for kubernetes' OpenAPI generated file.
+// This involves reading all go files in the source tree and looking for the
+// "+k8s:openapi-gen" tag. If present, then that package must be supplied to
+// the genrule.
+func (v *Vendorer) walkGenerated() error {
+	if !v.cfg.K8sOpenAPIGen {
+		return nil
+	}
+	v.managedAttrs = append(v.managedAttrs, "openapi_targets", "vendor_targets")
+	paths, err := v.findOpenAPI(v.root)
+	if err != nil {
+		return err
+	}
+	return v.addGeneratedOpenAPIRule(paths)
+}
+
+// findOpenAPI searches for all packages under root that request OpenAPI. It
+// returns the go import paths. It does not follow symlinks.
+func (v *Vendorer) findOpenAPI(root string) ([]string, error) {
+	finfos, err := ioutil.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+	var res []string
+	var includeMe bool
+	for _, finfo := range finfos {
+		path := filepath.Join(root, finfo.Name())
+		if finfo.IsDir() && (finfo.Mode()&os.ModeSymlink == 0) {
+			children, err := v.findOpenAPI(path)
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, children...)
+		} else if strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") {
+			b, err := ioutil.ReadFile(path)
+			if err != nil {
+				return nil, err
+			}
+			if bytes.Contains(b, []byte(openAPIGenTag)) {
+				includeMe = true
+			}
+		}
+	}
+	if includeMe {
+		pkg, err := v.ctx.ImportDir(root, 0)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, pkg.ImportPath)
+	}
+	return res, nil
+}
+
+// addGeneratedOpenAPIRule updates the pkg/generated/openapi go_default_library
+// rule with the automanaged openapi_targets and vendor_targets.
+func (v *Vendorer) addGeneratedOpenAPIRule(paths []string) error {
+	var openAPITargets []string
+	var vendorTargets []string
+	for _, p := range paths {
+		if !strings.HasPrefix(p, baseImport) {
+			return fmt.Errorf("openapi-gen path outside of kubernetes: %s", p)
+		}
+		np := p[len(baseImport):]
+		if strings.HasPrefix(np, staging) {
+			vendorTargets = append(vendorTargets, np[len(staging):])
+		} else {
+			openAPITargets = append(openAPITargets, np)
+		}
+	}
+	sort.Strings(openAPITargets)
+	sort.Strings(vendorTargets)
+
+	pkgPath := filepath.Join("pkg", "generated", "openapi")
+	for _, r := range v.newRules[pkgPath] {
+		if r.Name() == "go_default_library" {
+			r.SetAttr("openapi_targets", asExpr(openAPITargets))
+			r.SetAttr("vendor_targets", asExpr(vendorTargets))
+			break
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/pull/41106 for some more context. This automanages this rule in `pkg/generated/openapi/BUILD`:
```
openapi_library(
    name = "go_default_library",
    srcs = ["doc.go"],
    openapi_targets = [
        "cmd/libs/go2idl/client-gen/test_apis/testgroup/v1",
        "federation/apis/federation/v1beta1",
        "pkg/api/v1",
        "pkg/apis/abac/v0",
        "pkg/apis/abac/v1beta1",
        "pkg/apis/apps/v1beta1",
        "pkg/apis/authentication/v1",
        "pkg/apis/authentication/v1beta1",
        "pkg/apis/authorization/v1",
        "pkg/apis/authorization/v1beta1",
        "pkg/apis/autoscaling/v1",
        "pkg/apis/autoscaling/v2alpha1",
        "pkg/apis/batch/v1",
        "pkg/apis/batch/v2alpha1",
        "pkg/apis/certificates/v1beta1",
        "pkg/apis/componentconfig/v1alpha1",
        "pkg/apis/extensions/v1beta1",
        "pkg/apis/imagepolicy/v1alpha1",
        "pkg/apis/policy/v1beta1",
        "pkg/apis/rbac/v1alpha1",
        "pkg/apis/rbac/v1beta1",
        "pkg/apis/storage/v1beta1",
        "pkg/version",
    ],
    tags = ["automanaged"],
    vendor_targets = [
        "k8s.io/apimachinery/pkg/api/resource",
        "k8s.io/apimachinery/pkg/apis/meta/v1",
        "k8s.io/apimachinery/pkg/runtime",
        "k8s.io/apimachinery/pkg/util/intstr",
        "k8s.io/apimachinery/pkg/version",
        "k8s.io/apiserver/pkg/apis/example/v1",
        "k8s.io/client-go/pkg/api/v1",
    ],
)
```