### PR TITLE
support go 1.8

### DIFF
--- a/gazel/gazel.go
+++ b/gazel/gazel.go
@@ -741,7 +741,7 @@ func context() *build.Context {
 		GOOS:        "linux",
 		GOROOT:      build.Default.GOROOT,
 		GOPATH:      build.Default.GOPATH,
-		ReleaseTags: []string{"go1.1", "go1.2", "go1.3", "go1.4", "go1.5", "go1.6", "go1.7"},
+		ReleaseTags: []string{"go1.1", "go1.2", "go1.3", "go1.4", "go1.5", "go1.6", "go1.7", "go1.8"},
 		Compiler:    runtime.Compiler,
 		CgoEnabled:  true,
 	}


### PR DESCRIPTION
build constraints should handle 1.7 versions