### PR TITLE
Delete the rules_go load rule if it's not needed

### DIFF
--- a/gazel/gazel.go
+++ b/gazel/gazel.go
@@ -690,6 +690,10 @@ func reconcileLoad(f *bzl.File, rules []*bzl.Rule) {
 		if args[0] != goRulesLabel {
 			continue
 		}
+		if len(usedRuleKindsList) == 0 {
+			f.DelRules(r.Kind(), r.Name())
+			continue
+		}
 		r.Call.List = asExpr(append(
 			[]string{goRulesLabel}, usedRuleKindsList...,
 		)).(*bzl.ListExpr).List


### PR DESCRIPTION
If you try generating `vendor/BUILD` from scratch with `VendorMultipleBuildFiles` enabled, we add a useless load line:
```
load("@io_bazel_rules_go//go:def.bzl")
```
Simplest fix is to automatically remove this line in reconciliation when we don't need it.

x-ref https://github.com/kubernetes/kubernetes/pull/41287#issuecomment-295969726.